### PR TITLE
Added all HexstreamSoft "ready-to-use" libraries. (Except CLHS wrapper.)

### DIFF
--- a/projects/anaphoric-variants.json
+++ b/projects/anaphoric-variants.json
@@ -1,0 +1,12 @@
+{
+  "name": "anaphoric-variants",
+  "homepage": "https://www.hexstreamsoft.com/libraries/anaphoric-variants/",
+  "shortdesc": {
+    "en": "Gives access to anaphoric variants of operators through one macro: ANAPHORIC. The user explicitly provides a variable name, preserving sanity, in contrast to the traditional use of an evil implicit variable (\"IT\"). Some operators can bind additional handy variables when explicitly requested."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/anaphoric-variants",
+    "location": "https://github.com/Hexstream/anaphoric-variants.git"
+  },
+  "license": "https://github.com/Hexstream/anaphoric-variants/blob/master/UNLICENSE"
+}

--- a/projects/bubble-operator-upwards.json
+++ b/projects/bubble-operator-upwards.json
@@ -1,0 +1,12 @@
+{
+  "name": "bubble-operator-upwards",
+  "homepage": "https://www.hexstreamsoft.com/libraries/bubble-operator-upwards/",
+  "shortdesc": {
+    "en": "A function that \"bubbles an operator upwards\" in a form, demultiplexing all alternative branches by way of cartesian product. This operation is notably useful for easy implementation of certain kinds of shorthand notations in macros. A cartesian-product function is also exported, as it's needed to implement the main function."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/bubble-operator-upwards",
+    "location": "https://github.com/Hexstream/bubble-operator-upwards.git"
+  },
+  "license": "https://github.com/Hexstream/bubble-operator-upwards/blob/master/UNLICENSE"
+}

--- a/projects/cartesian-product-switch.json
+++ b/projects/cartesian-product-switch.json
@@ -1,0 +1,12 @@
+{
+  "name": "cartesian-product-switch",
+  "homepage": "https://www.hexstreamsoft.com/libraries/cartesian-product-switch/",
+  "shortdesc": {
+    "en": "A macro for choosing the appropriate form to execute according to the combined results of multiple tests. This is a straightforward and efficient alternative to the convoluted ad-hoc conditionals one might otherwise resort to."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/cartesian-product-switch",
+    "location": "https://github.com/Hexstream/cartesian-product-switch.git"
+  },
+  "license": "https://github.com/Hexstream/cartesian-product-switch/blob/master/UNLICENSE"
+}

--- a/projects/definitions-systems.json
+++ b/projects/definitions-systems.json
@@ -1,0 +1,12 @@
+{
+  "name": "definitions-systems",
+  "homepage": "https://www.hexstreamsoft.com/libraries/definitions-systems/",
+  "shortdesc": {
+    "en": "Provides a simple unified extensible way of processing named definitions."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/definitions-systems",
+    "location": "https://github.com/Hexstream/definitions-systems.git"
+  },
+  "license": "https://github.com/Hexstream/definitions-systems/blob/master/UNLICENSE"
+}

--- a/projects/enhanced-eval-when.json
+++ b/projects/enhanced-eval-when.json
@@ -1,0 +1,12 @@
+{
+  "name": "enhanced-eval-when",
+  "homepage": "https://www.hexstreamsoft.com/libraries/enhanced-eval-when/",
+  "shortdesc": {
+    "en": "Provides an enhanced EVAL-WHEN macro that supports (eval-when t ...) as a shorthand for (eval-when (:compile-toplevel :load-toplevel :execute) ...), addressing concerns about verbosity. An ENHANCED-EVAL-WHEN alias is also supported, as well as an EVAL-ALWAYS macro and package nickname, for good measure."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/enhanced-eval-when",
+    "location": "https://github.com/Hexstream/enhanced-eval-when.git"
+  },
+  "license": "https://github.com/Hexstream/enhanced-eval-when/blob/master/UNLICENSE"
+}

--- a/projects/enhanced-multiple-value-bind.json
+++ b/projects/enhanced-multiple-value-bind.json
@@ -1,0 +1,12 @@
+{
+  "name": "enhanced-multiple-value-bind",
+  "homepage": "https://www.hexstreamsoft.com/libraries/enhanced-multiple-value-bind/",
+  "shortdesc": {
+    "en": "Provides an enhanced MULTIPLE-VALUE-BIND macro that adds support for lambda keywords by expanding to a MULTIPLE-VALUE-CALL when necessary. This makes catching multiple-value &rest and &key much more lightweight and convenient. A MULTIPLE-VALUE-&BIND alias is supported."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/enhanced-multiple-value-bind",
+    "location": "https://github.com/Hexstream/enhanced-multiple-value-bind.git"
+  },
+  "license": "https://github.com/Hexstream/enhanced-multiple-value-bind/blob/master/UNLICENSE"
+}

--- a/projects/first-time-value.json
+++ b/projects/first-time-value.json
@@ -1,0 +1,12 @@
+{
+  "name": "first-time-value",
+  "homepage": "https://www.hexstreamsoft.com/libraries/first-time-value/",
+  "shortdesc": {
+    "en": "Returns the result of evaluating a form in the current lexical and dynamic context the first time it's encountered, and the cached result of that computation on subsequent evaluations."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/first-time-value",
+    "location": "https://github.com/Hexstream/first-time-value.git"
+  },
+  "license": "https://github.com/Hexstream/first-time-value/blob/master/UNLICENSE"
+}

--- a/projects/incognito-keywords.json
+++ b/projects/incognito-keywords.json
@@ -1,0 +1,12 @@
+{
+  "name": "incognito-keywords",
+  "homepage": "https://www.hexstreamsoft.com/libraries/incognito-keywords/",
+  "shortdesc": {
+    "en": "Introduces a new kind of keyword that looks just like any non-keyword symbol and allows safe usage of convenient but clashy symbol names by multiple libraries without conflicts through sharing. Some names that might benefit are (alist blist plist macro operator index &doc &decl &rest+ &destructure &ignored &ignorable)."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/incognito-keywords",
+    "location": "https://github.com/Hexstream/incognito-keywords.git"
+  },
+  "license": "https://github.com/Hexstream/incognito-keywords/blob/master/UNLICENSE"
+}

--- a/projects/its.json
+++ b/projects/its.json
@@ -1,0 +1,12 @@
+{
+  "name": "its",
+  "homepage": "https://www.hexstreamsoft.com/libraries/its/",
+  "shortdesc": {
+    "en": "Provides convenient access to multiple values of an object in a concise, explicit and efficient way."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/its",
+    "location": "https://github.com/Hexstream/its.git"
+  },
+  "license": "https://github.com/Hexstream/its/blob/master/UNLICENSE"
+}

--- a/projects/macro-level.json
+++ b/projects/macro-level.json
@@ -1,0 +1,12 @@
+{
+  "name": "macro-level",
+  "homepage": "https://www.hexstreamsoft.com/libraries/macro-level/",
+  "shortdesc": {
+    "en": "An embarassingly trivial convenience macro that saves on indentation while being more concise and direct. (macro-level ...) == (macrolet ((m () ...)) (m))"
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/macro-level",
+    "location": "https://github.com/Hexstream/macro-level.git"
+  },
+  "license": "https://github.com/Hexstream/macro-level/blob/master/UNLICENSE"
+}

--- a/projects/map-bind.json
+++ b/projects/map-bind.json
@@ -1,0 +1,12 @@
+{
+  "name": "map-bind",
+  "homepage": "https://www.hexstreamsoft.com/libraries/map-bind/",
+  "shortdesc": {
+    "en": "A macro that allows visual grouping of variables with their corresponding values (not necessarily 1:1) in calls to mapping operators when using an inline LAMBDA. It does so in a way that automatically supports virtually every existing and future mapping operator, all lambda keywords and FUNCALL/APPLY/MULTIPLE-VALUE-CALL variations."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/map-bind",
+    "location": "https://github.com/Hexstream/map-bind.git"
+  },
+  "license": "https://github.com/Hexstream/map-bind/blob/master/UNLICENSE"
+}

--- a/projects/multiple-value-variants.json
+++ b/projects/multiple-value-variants.json
@@ -1,0 +1,12 @@
+{
+  "name": "multiple-value-variants",
+  "homepage": "https://www.hexstreamsoft.com/libraries/multiple-value-variants/",
+  "shortdesc": {
+    "en": "Gives access to multiple-value variants of operators through one macro: MULTIPLE-VALUE. There are built-in variants for some standard operators; it's easy to create your own variants for other operators. The multiple-value mapping operators are especially useful."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/multiple-value-variants",
+    "location": "https://github.com/Hexstream/multiple-value-variants.git"
+  },
+  "license": "https://github.com/Hexstream/multiple-value-variants/blob/master/UNLICENSE"
+}

--- a/projects/parse-number-range.json
+++ b/projects/parse-number-range.json
@@ -1,0 +1,12 @@
+{
+  "name": "parse-number-range",
+  "homepage": "https://www.hexstreamsoft.com/libraries/parse-number-range/",
+  "shortdesc": {
+    "en": "Parses LOOP's convenient \"for-as-arithmetic\" syntax into 5 simple values: from, to, limit-kind (:inclusive, :exclusive or nil if unbounded), by (step) and direction (+ or -)). Further related utilities are provided. Intended for easy implementation of analogous functionality in other constructs."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/parse-number-range",
+    "location": "https://github.com/Hexstream/parse-number-range.git"
+  },
+  "license": "https://github.com/Hexstream/parse-number-range/blob/master/UNLICENSE"
+}

--- a/projects/place-modifiers.json
+++ b/projects/place-modifiers.json
@@ -1,0 +1,12 @@
+{
+  "name": "place-modifiers",
+  "homepage": "https://www.hexstreamsoft.com/libraries/place-modifiers/",
+  "shortdesc": {
+    "en": "Essentially gives access to hundreds of modify-macros through one single macro: MODIFY."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/place-modifiers",
+    "location": "https://github.com/Hexstream/place-modifiers.git"
+  },
+  "license": "https://github.com/Hexstream/place-modifiers/blob/master/UNLICENSE"
+}

--- a/projects/place-utils.json
+++ b/projects/place-utils.json
@@ -1,0 +1,12 @@
+{
+  "name": "place-utils",
+  "homepage": "https://www.hexstreamsoft.com/libraries/place-utils/",
+  "shortdesc": {
+    "en": "Provides a few utilities relating to setfable places."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/place-utils",
+    "location": "https://github.com/Hexstream/place-utils.git"
+  },
+  "license": "https://github.com/Hexstream/place-utils/blob/master/UNLICENSE"
+}

--- a/projects/positional-lambda.json
+++ b/projects/positional-lambda.json
@@ -1,0 +1,12 @@
+{
+  "name": "positional-lambda",
+  "homepage": "https://www.hexstreamsoft.com/libraries/positional-lambda/",
+  "shortdesc": {
+    "en": "A concise, intuitive and flexible syntax (macro) for trivial lambdas that eschews explicit (and often contextually-redundant) naming of parameter variables in favor of positional references, with support for a used or ignored &rest parameter and automatic declaration of ignored parameters when logical \"gaps\" are left in the positional references. Further convenience features are provided."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/positional-lambda",
+    "location": "https://github.com/Hexstream/positional-lambda.git"
+  },
+  "license": "https://github.com/Hexstream/positional-lambda/blob/master/UNLICENSE"
+}

--- a/projects/symbol-namespaces.json
+++ b/projects/symbol-namespaces.json
@@ -1,0 +1,12 @@
+{
+  "name": "symbol-namespaces",
+  "homepage": "https://www.hexstreamsoft.com/libraries/symbol-namespaces/",
+  "shortdesc": {
+    "en": "Defines a new kind of package that's named by a symbol rather than a string and that maps from existing symbols to their respective \"implicitly managed\" counterparts. The motivating use-case is to conceptually allow multiple definitions of the same kind on a single symbol, without conflicts."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/symbol-namespaces",
+    "location": "https://github.com/Hexstream/symbol-namespaces.git"
+  },
+  "license": "https://github.com/Hexstream/symbol-namespaces/blob/master/UNLICENSE"
+}

--- a/projects/trivial-jumptables.json
+++ b/projects/trivial-jumptables.json
@@ -1,0 +1,12 @@
+{
+  "name": "trivial-jumptables",
+  "homepage": "https://www.hexstreamsoft.com/libraries/trivial-jumptables/",
+  "shortdesc": {
+    "en": "Provides efficient O(1) jumptables on supported Common Lisp implementations and falls back to O(log(n)) on others."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/trivial-jumptables",
+    "location": "https://github.com/Hexstream/trivial-jumptables.git"
+  },
+  "license": "https://github.com/Hexstream/trivial-jumptables/blob/master/UNLICENSE"
+}

--- a/projects/with-shadowed-bindings.json
+++ b/projects/with-shadowed-bindings.json
@@ -1,0 +1,12 @@
+{
+  "name": "with-shadowed-bindings",
+  "homepage": "https://www.hexstreamsoft.com/libraries/with-shadowed-bindings/",
+  "shortdesc": {
+    "en": "Establishes a new lexical context within which specified bindings are explicitly shadowed, making it clear that they are not referenced within, thereby reducing cognitive load."
+  },
+  "repository": {
+    "browse": "https://github.com/Hexstream/with-shadowed-bindings",
+    "location": "https://github.com/Hexstream/with-shadowed-bindings.git"
+  },
+  "license": "https://github.com/Hexstream/with-shadowed-bindings/blob/master/UNLICENSE"
+}


### PR DESCRIPTION
3 unrelated clarifications:

All my libraries are in the public domain (Unlicense), except the CLHS wrapper which wraps the CLHS, a very proprietary component.

My public libraries are in 3 possible states, "ready-to-use", "not-yet-ready" and "not-yet-scavenged".

For now I've just used my "official" library descriptions as the "shortdesc", some of these might be deemed too long. Let me know if that's the case.